### PR TITLE
v3.8.6: possible ratelimit fixes

### DIFF
--- a/libs/rest/API.lua
+++ b/libs/rest/API.lua
@@ -119,7 +119,8 @@ function API:request(method, endpoint, payload, key, base)
 end
 
 function API:commit(method, url, headers, payload, retries)
-	if self._client then
+	local client = self._client
+	if client then
 		self._client:debug("%s %s", method, url)
 	end
 	local success, result, body = pcall(http.request, method, url, headers, payload)
@@ -141,7 +142,7 @@ function API:commit(method, url, headers, payload, retries)
 	local delay = 0
 	if result.code < 300 then
 		return data, nil, result
-	elseif result.code == 422 and self._client and self._client._options and self._client._options.offlineEmpty then
+	elseif result.code == 422 and client and client._options and client._options.offlineEmpty then
 		return {}, nil, result
 	elseif result.code == 429 then
 		if type(data) == "table" and data.retry_after and data.retry_after ~= json.null then
@@ -169,7 +170,6 @@ function API:commit(method, url, headers, payload, retries)
 		err = string.format("HTTP Error %i : %s", result.code or 0, result.reason or "Unknown")
 	end
 
-	local client = self._client
 	if client and not (client._options and client._options.ignoredErrorCodes and client._options.ignoredErrorCodes[tostring(data.code or 0)]) then
 		client:error(err)
 	end

--- a/libs/rest/API.lua
+++ b/libs/rest/API.lua
@@ -11,10 +11,6 @@ local USER_AGENT = "ERLua (https://github.com/NickIsADev/erlua, " .. package.ver
 
 local payloadRequired = { POST = true, PATCH = true, PUT = true }
 
-local function urlencode(obj)
-	return (string.gsub(tostring(obj), "%W", tohex))
-end
-
 local function realtime()
 	local seconds, microseconds = uv.gettimeofday()
 	return seconds + (microseconds / 1000000)
@@ -88,6 +84,7 @@ function API:request(method, endpoint, payload, key, base)
 			self._client:info("Bucket %s is ratelimited; waiting %.2fms", bucketName, delay)
 		end
 		timer.sleep(delay)
+		now = realtime()
 	end
 
 	local holding = true
@@ -100,10 +97,18 @@ function API:request(method, endpoint, payload, key, base)
 	local data, err, headers = self:commit(method, url, headers, payload, 0)
 
 	if headers then
-		bucket.remaining = tonumber(headers["x-ratelimit-remaining"]) or bucket.remaining
-		bucket.limit = tonumber(headers["x-ratelimit-limit"]) or bucket.limit
-		bucket.reset = tonumber(headers["x-ratelimit-reset"]) or bucket.reset
-		bucket.reset = bucket.reset and bucket.reset + 0.05 -- buffer
+		local limit = tonumber(headers["x-ratelimit-limit"])
+		local remaining = tonumber(headers["x-ratelimit-remaining"])
+		local reset = tonumber(headers["x-ratelimit-reset"])
+
+		if limit then bucket.limit = limit end
+		if reset then bucket.reset = reset + 0.1 end -- 100ms buffer
+
+		if remaining then
+			if remaining < bucket.remaining or bucket.remaining <= 0 then
+				bucket.remaining = remaining
+			end
+		end
 	end
 
 	if holding then
@@ -136,13 +141,17 @@ function API:commit(method, url, headers, payload, retries)
 	local delay = 0
 	if result.code < 300 then
 		return data, nil, result
-	elseif result.code == 422 and client and client._options and client._options.offlineEmpty then
+	elseif result.code == 422 and self._client and self._client._options and self._client._options.offlineEmpty then
 		return {}, nil, result
-	elseif result.code == 429 and type(data) == "table" and data.retry_after and data.retry_after ~= json.null then
-		delay = data.retry_after * 1000
+	elseif result.code == 429 then
+		if type(data) == "table" and data.retry_after and data.retry_after ~= json.null then
+			delay = data.retry_after * 1000
+		elseif result["retry-after"] then
+			delay = tonumber(result["retry-after"]) * 1000
+		end
 		retry = retries < 2
 	elseif result.code == 502 then
-		delay = math.random(0, 2000)
+		delay = math.random(500, 2000)
 		retry = retries < 2
 	end
 

--- a/package.lua
+++ b/package.lua
@@ -1,6 +1,6 @@
 return {
     name = "NickIsADev/erlua",
-    version = "3.8.5",
+    version = "3.8.6",
     description = "A scalable library with TTL data caching, classes, and ratelimit handling for the ERLC API v2.",
     license = "MIT",
     files = {


### PR DESCRIPTION
- Removed unused "urlencode" function
- Made "now" variable be updated after waiting for bucket ratelimit
- Improved bucket ratelimit status updating after request has been made
- Fixed client variable issue on 422 error code
- Added min delay of 500 ms on 502 error code instead of 0 ms